### PR TITLE
chore: bump deepgram-sdk floor to >=7.7.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: Test
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - run: pip install -r requirements.txt
+      - run: python -m unittest discover -s tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-deepgram-sdk>=7.6.0
+deepgram-sdk>=7.7.0
 flask==3.1.0
 flask-cors==5.0.0
 PyJWT==2.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-deepgram-sdk>=7.7.0
+deepgram-sdk>=7.7.0,<8.0.0
 flask==3.1.0
 flask-cors==5.0.0
 PyJWT==2.10.1

--- a/tests/test_sdk_redaction.py
+++ b/tests/test_sdk_redaction.py
@@ -1,0 +1,11 @@
+import unittest
+
+from deepgram.core import ApiError
+
+
+class SdkRedactionTest(unittest.TestCase):
+    def test_api_error_redacts_authorization_value(self):
+        marker = "synthetic-api-key"
+        error = ApiError(headers={"Authorization": f"Token {marker}"})
+
+        self.assertNotIn(marker, str(error))


### PR DESCRIPTION
Bumps the `deepgram-sdk` floor from `>=7.6.0` to `>=7.7.0`.

7.7.0 masks the `Authorization` header in `ApiError` string output; 7.6.0 emitted the raw `Token <api-key>`. Raising the floor guarantees SDK-side credential redaction. Consistency bump across the Python starters.